### PR TITLE
Adding Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.idea/
+Vagrant/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.5-slim
+FROM python:3.7-slim-stretch
 
 WORKDIR /tmp
 COPY . .
 
-RUN echo 'deb http://deb.debian.org/debian jessie main non-free' > /etc/apt/sources.list \
+RUN echo 'deb http://deb.debian.org/debian stretch main non-free' > /etc/apt/sources.list \
     && apt-get -q update \
     && BUILD_PACKAGES='wget build-essential libffi-dev libfdk-aac-dev automake autoconf' \
     && apt-get install -qy --force-yes $BUILD_PACKAGES lame flac faac libav-tools vorbis-tools opus-tools \
@@ -15,7 +15,7 @@ RUN echo 'deb http://deb.debian.org/debian jessie main non-free' > /etc/apt/sour
         && make install \
         && cd .. \
     && ARCHIVE=libspotify-12.1.51-Linux-$(uname -m)-release \
-    && wget https://developer.spotify.com/download/libspotify/${ARCHIVE}.tar.gz \
+    && wget -O ${ARCHIVE}.tar.gz https://github.com/mopidy/libspotify-archive/blob/master/${ARCHIVE}.tar.gz?raw=true \
         && tar xvf ${ARCHIVE}.tar.gz \
         && cd ${ARCHIVE}/ \
         && make install prefix=/usr/local \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-stretch
+FROM python:3.4-slim-stretch
 
 WORKDIR /tmp
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.5-slim
+
+WORKDIR /tmp
+COPY . .
+
+RUN apt-add-repository multiverse \
+    && apt-get -q update \
+    && BUILD_PACKAGES='wget build-essential libffi-dev libfdk-aac-dev automake autoconf' \
+    && apt-get install -qy --force-yes $BUILD_PACKAGES lame flac faac libav-tools vorbis-tools opus-tools \
+    && wget https://github.com/nu774/fdkaac/archive/v0.6.3.tar.gz \
+        && tar xvf v0.6.3.tar.gz \
+        && cd fdkaac-0.6.3 \
+        && autoreconf -i \
+        && ./configure \
+        && make install \
+        && cd .. \
+    && ARCHIVE=libspotify-12.1.51-Linux-$(uname -m)-release \
+    && wget https://developer.spotify.com/download/libspotify/${ARCHIVE}.tar.gz \
+        && tar xvf ${ARCHIVE}.tar.gz \
+        && cd ${ARCHIVE}/ \
+        && make install prefix=/usr/local \
+        && cd .. \
+        && python setup.py install \
+    && apt-get remove --purge -qy --force-yes $BUILD_PACKAGES \
+    && apt-get autoremove -qy --force-yes \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/*
+
+WORKDIR /data
+VOLUME ["/data"]
+CMD ["spotify-ripper"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.5-slim
 WORKDIR /tmp
 COPY . .
 
-RUN apt-add-repository multiverse \
+RUN echo 'deb http://deb.debian.org/debian jessie main non-free' > /etc/apt/sources.list \
     && apt-get -q update \
     && BUILD_PACKAGES='wget build-essential libffi-dev libfdk-aac-dev automake autoconf' \
     && apt-get install -qy --force-yes $BUILD_PACKAGES lame flac faac libav-tools vorbis-tools opus-tools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ RUN echo 'deb http://deb.debian.org/debian stretch main non-free' > /etc/apt/sou
 
 WORKDIR /data
 VOLUME ["/data"]
-CMD ["spotify-ripper"]
+ENTRYPOINT ["spotify-ripper"]
+CMD ["--help"]

--- a/README.rst
+++ b/README.rst
@@ -446,7 +446,9 @@ To run the image:
       spotify-ripper -d /data spotify:track:52xaypL0Kjzk0ngwv3oBPR
 
 In the above example:
+
 - Ripped files will be stored in host machine's ``~/Music`` folder, mapped to container's ``/data`` folder
+
 - Configuration & Spotify key will be read from ``~/.spotify-ripper``
 
 Optional Encoding Formats

--- a/README.rst
+++ b/README.rst
@@ -439,12 +439,11 @@ To run the image:
 
 .. code:: bash
 
-    $ docker run --rm \ # Run & remove container after it finishes
-      -it \ # Interactive mode
-      -v ~/Music:/data \ # Mount volume where ripped files are to be stored
-      -v ~/.spotify-ripper:/root/.spotify-ripper \ # Mount volume containing config.ini & spotify_appkey.key
-      spotify-ripper \ # Docker image name
-      spotify-ripper -d /data spotify:track:52xaypL0Kjzk0ngwv3oBPR # Command to be executed
+    $ docker run -it --rm \
+      -v ~/Music:/data \
+      -v ~/.spotify-ripper:/root/.spotify-ripper \
+      spotify-ripper:latest \
+      spotify-ripper -d /data spotify:track:52xaypL0Kjzk0ngwv3oBPR
 
 In the above example:
 - Ripped files will be stored in host machine's ``~/Music`` folder, mapped to container's ``/data`` folder

--- a/README.rst
+++ b/README.rst
@@ -424,6 +424,32 @@ Windows
 Unfortunately, pyspotify seems to have an issue building on Windows (if someone can get this to work, please let me know). The best alternative is to run a linux distribution in a virtual machine.  Basic instructions to install Ubuntu on Virtual Box can be found in the `wiki <https://github.com/hbashton-ripper/wiki/Windows>`__.
 
 
+Docker
+~~~~~~
+
+It's also possible to build & run spotify-ripper as a Docker container.
+
+To build the image:
+
+.. code:: bash
+
+    $ docker build -t spotify-ripper:latest .
+
+To run the image:
+
+.. code:: bash
+
+    $ docker run --rm \ # Run & remove container after it finishes
+      -it \ # Interactive mode
+      -v ~/Music:/data \ # Mount volume where ripped files are to be stored
+      -v ~/.spotify-ripper:/root/.spotify-ripper \ # Mount volume containing config.ini & spotify_appkey.key
+      spotify-ripper \ # Docker image name
+      spotify-ripper -d /data spotify:track:52xaypL0Kjzk0ngwv3oBPR # Command to be executed
+
+In the above example:
+- Ripped files will be stored in host machine's ``~/Music`` folder, mapped to container's ``/data`` folder
+- Configuration & Spotify key will be read from ``~/.spotify-ripper``
+
 Optional Encoding Formats
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -443,7 +443,7 @@ To run the image:
       -v ~/Music:/data \
       -v ~/.spotify-ripper:/root/.spotify-ripper \
       spotify-ripper:latest \
-      spotify-ripper -d /data spotify:track:52xaypL0Kjzk0ngwv3oBPR
+      -d /data spotify:track:52xaypL0Kjzk0ngwv3oBPR
 
 In the above example:
 


### PR DESCRIPTION
Added ability to build & run spotify-ripper in Docker, without the need of manual installation or resource-hungry VMs

The resulting image is based on the official `python:3.5-slim` image and is 268MB in size