### PR TITLE
Fix cover art download

### DIFF
--- a/spotify_ripper/tags.py
+++ b/spotify_ripper/tags.py
@@ -72,7 +72,7 @@ def set_metadata_tags(args, audio_file, idx, track, ripper):
 
         # cover art image
         def get_cover_image(image_link):
-            image_link = 'http://open.spotify.com%s' % (
+            image_link = 'https://i.scdn.co%s' % (
                 image_link[len('spotify'):].replace(':', '/'))
             cover_file = urllib.urlretrieve(image_link)[0]
             


### PR DESCRIPTION
I've made some changes to **tags.py** and fixed the cover art download bug #51.

The bug seemed to be in the `image.load` function in the main spotify library. It returns True but no data is getting loaded. So I replaced it by a `urllib.urlretrieve` call that saves the cover art to a temp file, and retrieves the data in a variable `image`.

I also changed the cover url to get the higher resolution available (640px for now) using the `track.album.cover(2)` option.

Please let me know if there is any issue.